### PR TITLE
Added ability to create multiple browser instances in test

### DIFF
--- a/examples/visitgoogle.js
+++ b/examples/visitgoogle.js
@@ -4,6 +4,7 @@
 // $browser = webdriver session
 // $driver = driver libraries
 // console.log will output to AWS Lambda logs (via Cloudwatch)
+// $browser2 = chromium.createSession() in case you need a second user in the same test
 
 console.log('About to visit google.com...');
 $browser.get('http://www.google.com/ncr');

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ exports.handler = (event, context, callback) => {
 
   // Start selenium webdriver session
   $browser = chromium.createSession();
-  sandbox.executeScript(inputBuffer, $browser, webdriver, function(err) {
+  sandbox.executeScript(inputBuffer, $browser, webdriver, chromium, function(err) {
     if (process.env.DEBUG_ENV) {
       log(child.execSync('ps aux').toString());
     }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1,11 +1,12 @@
 const vm = require('vm');
 
-exports.executeScript = function(scriptText, browser, driver, cb) {
+exports.executeScript = function(scriptText, browser, driver, chromium, cb) {
   // Create Sandbox VM
   const sandbox = {
     '$browser': browser,
     '$driver': driver,
-    'console': console
+    'console': console,
+    'chromium': chromium
   };
 
   const script = new vm.Script(scriptText);


### PR DESCRIPTION
Sometimes a test requires multiple users with different sessions. For example, when testing how one user can send an interactive message via browser to another.

In this pull request "chromium" is exposed into sandbox, so that it's possible to create new browser instances by executing "chromium.createSession();" inside of the test.