### PR TITLE
Modclean is not optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This uses a special version of Chrome (headless chromium) from the [serverless-c
 * An AWS Account
 * The [AWS SAM Local](https://github.com/awslabs/aws-sam-local) running functions locally with the [Serverless Application Model](https://github.com/awslabs/serverless-application-model) (see: `template.yaml`, install: `npm install -g aws-sam-local`)
 * node.js + npm
-* `modclean` npm modules for reducing function size (optional)
+* `modclean` npm modules for reducing function size
 * Bash
 
 #### Local development setup


### PR DESCRIPTION
in fetch-dependencies, it is required.
```
if ! [ -x "$(command -v modclean)" ]; then
  echo 'Error: modclean is not installed. To install: npm i -g modclean' >&2
  exit 1
fi
```

p.s. great job with the project!